### PR TITLE
Add support for configuration persistance.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,10 +121,12 @@ jobs:
       timeout-minutes: 1
       run: |
         echo "SFTP login and upload"
-        echo -n "test_password" > pwfile
-        echo y | pscp -sftp -P 10022 -l test_user -pwfile pwfile README.rst localhost:README.rst
+        # Putty 0.76 has no support for loading from file.
+        # Once GitHub Actions has newer Ubuntu,
+        # we can put the password in a file and load it with -pwfile
+        echo y | pscp -sftp -P 10022 -l test_user -pw test_password README.rst localhost:README.rst
         echo "SFTP download"
-        pscp -sftp -P 10022 -l test_user -pwfile pwfile localhost:README.rst test-download.rst
+        pscp -sftp -P 10022 -l test_user -pw test_password localhost:README.rst test-download.rst
         echo "Compare download result"
         cmp README.rst test-download.rst
         rm test-download.rst

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,133 @@
+#
+# Actions executed on GitHub VMs.
+#
+#
+name: web
+
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+
+concurrency:
+  group: web-${{ github.ref }}
+  cancel-in-progress: true
+
+
+env:
+  DOCKER_HOST: 'disabled'
+  DEBIAN_FRONTEND: noninteractive
+  CI: 'true'
+  USER: 'runner'
+
+
+jobs:
+
+  image-build:
+    runs-on: ubuntu-22.04
+    name: ${{ matrix.test.platform }} - ${{ matrix.tests }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - platform: lnx-64
+            base_image: ubuntu:22.04
+        test:
+          - platform: rhel4-64
+            base_image: centos:8
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Get SFTPPlus software and test tools.
+      run: |
+        sudo apt-get update
+        sudo apt-get install putty
+        curl -LO https://download.sftpplus.com/trial/sftpplus-${{ matrix.test.platform }}-trial.tar.gz
+
+    - name: Build image
+      timeout-minutes: 10
+      run: |
+        docker build \
+          --build-arg "target_platform=${{ matrix.test.platform }}" \
+          --build-arg "base_image=${{ matrix.test.base_image }}" \
+          --build-arg "sftpplus_version=trial" \
+          --tag sftpplus:gha-ci .
+
+    - name: Start the container
+      timeout-minutes: 10
+      run: |
+        docker run --detach --name sftpplus-trial-instance \
+        --publish 10020:10020 \
+        --publish 10443:10443 \
+        --publish 10022:10022 \
+        --publish 10021:10021 \
+        --publish 10900-10910:10900-10910 \
+        sftpplus:gha-ci
+
+    - name: Test HTTPS
+      timeout-minutes: 10
+      run: |
+        curl -k https://localhost:10020
+        curl -k https://localhost:10443/home/
+
+        # HTTPS session login.
+        curl -k --data 'username=test_user' --data 'password=test_password' \
+          -H 'Accept: application/json' \
+          https://localhost:10443/__chsps__/login
+
+        # REST basic-auth upload
+        curl -k -T README.rst https://test_user:test_password@docker.chevah.com:10443/home/README.rst
+
+        # REST file download
+        curl -k  https://test_user:test_password@docker.chevah.com:10443/home/README.rst -o test-download.txt
+        cmp --silent README.rst test-download.txt
+        rm test-download.txt
+
+    - name: Test FTPS
+      timeout-minutes: 10
+      run: |
+        # FTP login dir listing
+        curl -k --ftp-ssl ftp://test_user:test_password@docker.chevah.com:10021
+        # FTPS upload
+        curl -k --ftp-ssl  -T README.rst ftp://test_user:test_password@docker.chevah.com:10021
+        # FTPS download
+        curl -k --ftp-ssl ftp://test_user:test_password@docker.chevah.com:10021/README.rst -o test-download.rst
+        cmp --silent README.rst test-download.txt
+        rm test-download.txt
+
+    - name: Test SFTP
+      timeout-minutes: 10
+      run: |
+        # SFTP login and upload
+        echo -n "test_password" > pwfile
+        echo y | pscp -sftp -P 10022 -l test_user -pwfile pwfile README.rst docker.chevah.com:README.rst
+        # SFTP download
+        pscp -sftp -P 10022 -l test_user -pwfile pwfile docker.chevah.com:README.rst test-download.rst
+        cmp --silent README.rst test-download.txt
+        rm test-download.txt
+
+
+  # Helper so that on GitHub repo settings we can configure a single job as
+  # required.
+  ci-required:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    if:  ${{ !cancelled() }}
+    needs:
+      - image-build
+    steps:
+      - name: Require all successes
+        shell: python3 {0}
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,11 @@ jobs:
         cmp --silent README.rst test-download.txt
         rm test-download.txt
 
+    - name: Debug via tmate session
+      #if: runner.debug == "1"
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
   # Helper so that on GitHub repo settings we can configure a single job as
   # required.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     - name: Start the container
       timeout-minutes: 10
       run: |
-        docker run --detach --name sftpplus-trial-instance \
+        docker run --detach --name sftpplus-trial \
         --publish 10020:10020 \
         --publish 10443:10443 \
         --publish 10022:10022 \
@@ -68,14 +68,19 @@ jobs:
         --publish 10900-10910:10900-10910 \
         sftpplus:gha-ci
 
-    - name: Wait container start
+    - name: Wait container ports
       timeout-minutes: 1
       run: |
-        sleep 1
-        until $(curl --output /dev/null -k --silent --head --fail http://localhost:10020); do
-            printf 'Port 10020 not yet ready. Waiting 5 seconds.'
+        # The container will start, but it takes a few extra seconds for all
+        # the SFTPPlus servers inside the container to start.
+        # We wait for 10443 as this is started last by default.
+        until $(curl --output /dev/null -k --silent --head --fail http://localhost:10443); do
+            printf 'Port 10443 not yet ready. Waiting 5 seconds.'
             sleep 5
         done
+        # Wait just a bit more to be extra safe.
+        sleep 1
+        docker logs sftpplus-trial
 
     - name: Test HTTPS
       timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,6 @@ jobs:
         test:
           - platform: lnx-64
             base_image: ubuntu:22.04
-        test:
           - platform: rhel4-64
             base_image: centos:8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
         rm test-download.txt
 
     - name: Debug via tmate session
-      if: runner.debug == "1"
+      if: ${{ runner.debug == "1" }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         test:
           - platform: lnx-x64
             base_image: ubuntu:22.04
-          - platform: rhel4-x64
+          - platform: rhel8-x64
             base_image: centos:8
 
     steps:
@@ -67,6 +67,15 @@ jobs:
         --publish 10021:10021 \
         --publish 10900-10910:10900-10910 \
         sftpplus:gha-ci
+
+    - name: Wait container start
+      timeout-minutes: 1
+      run: |
+        sleep 1
+        until $(curl --output /dev/null -k --silent --head --fail http://localhost:10020); do
+            printf 'Port 10020 not yet ready. Waiting 5 seconds.'
+            sleep 5
+        done
 
     - name: Test HTTPS
       timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,10 +111,11 @@ jobs:
         rm test-download.txt
 
     - name: Debug via tmate session
-      #if: runner.debug == "1"
+      if: runner.debug == "1"
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
+
 
   # Helper so that on GitHub repo settings we can configure a single job as
   # required.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
         rm test-download.txt
 
     - name: Debug via tmate session
-      if: runner.debug == '1'
+      if: ${{ !cancelled() && runner.debug == '1' }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - platform: lnx-64
+          - platform: lnx-x64
             base_image: ubuntu:22.04
-          - platform: rhel4-64
+          - platform: rhel4-x64
             base_image: centos:8
 
     steps:
@@ -46,6 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install putty
         curl -LO https://download.sftpplus.com/trial/sftpplus-${{ matrix.test.platform }}-trial.tar.gz
+        la
 
     - name: Build image
       timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,7 @@ jobs:
   image-build:
     runs-on: ubuntu-22.04
     name: ${{ matrix.test.platform }} - ${{ matrix.test.base_image }}
-    # The job should be fast. We wait longer for debug sessions.
-    timeout-minutes: ${{ runner.debug == '1' && 60 || 10 }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +42,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Get SFTPPlus software and test tools.
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         sudo apt-get install putty
@@ -128,6 +128,7 @@ jobs:
 
     - name: Debug via tmate session
       if: ${{ !cancelled() && runner.debug == '1' }}
+      timeout-minutes: 60
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install putty
         curl -LO https://download.sftpplus.com/trial/sftpplus-${{ matrix.test.platform }}-trial.tar.gz
-        la
+        ls -al
 
     - name: Build image
       timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 # Actions executed on GitHub VMs.
 #
 #
-name: web
+name: ci
 
 
 on:
@@ -12,12 +12,11 @@ on:
 
 
 concurrency:
-  group: web-${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 
 env:
-  DOCKER_HOST: 'disabled'
   DEBIAN_FRONTEND: noninteractive
   CI: 'true'
   USER: 'runner'
@@ -27,7 +26,7 @@ jobs:
 
   image-build:
     runs-on: ubuntu-22.04
-    name: ${{ matrix.test.platform }} - ${{ matrix.tests }}
+    name: ${{ matrix.test.platform }} - ${{ matrix.test.base_image }}
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,9 +88,9 @@ jobs:
       timeout-minutes: 1
       run: |
         echo "Web UI"
-        curl -k https://localhost:10020
+        curl -k https://localhost:10020 > /dev/null
 
-        echo "HTTPS session login.""
+        echo "HTTPS session login."
         curl -k --data 'username=test_user' --data 'password=test_password' \
           -H 'Accept: application/json' \
           https://localhost:10443/__chsps__/login

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,8 @@ jobs:
   image-build:
     runs-on: ubuntu-22.04
     name: ${{ matrix.test.platform }} - ${{ matrix.test.base_image }}
-    timeout-minutes: 60
+    # The job should be fast. We wait longer for debug sessions.
+    timeout-minutes: ${{ runner.debug == '1' && 60 || 10 }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +50,7 @@ jobs:
         ls -al
 
     - name: Build image
-      timeout-minutes: 10
+      timeout-minutes: 5
       run: |
         docker build \
           --build-arg "target_platform=${{ matrix.test.platform }}" \
@@ -58,7 +59,7 @@ jobs:
           --tag sftpplus:gha-ci .
 
     - name: Start the container
-      timeout-minutes: 10
+      timeout-minutes: 5
       run: |
         docker run --detach --name sftpplus-trial \
         --publish 10020:10020 \
@@ -73,9 +74,10 @@ jobs:
       run: |
         # The container will start, but it takes a few extra seconds for all
         # the SFTPPlus servers inside the container to start.
+        # The first start takes longer as it will generate the TLS/SSH keys.
         # We wait for 10443 as this is started last by default.
         until $(curl --output /dev/null -k --silent --head --fail http://localhost:10443); do
-            printf 'Port 10443 not yet ready. Waiting 5 seconds.'
+            echo 'Port 10443 not yet ready. Waiting 5 seconds.'
             sleep 5
         done
         # Wait just a bit more to be extra safe.
@@ -83,7 +85,7 @@ jobs:
         docker logs sftpplus-trial
 
     - name: Test HTTPS
-      timeout-minutes: 10
+      timeout-minutes: 1
       run: |
         curl -k https://localhost:10020
         curl -k https://localhost:10443/home/
@@ -94,33 +96,33 @@ jobs:
           https://localhost:10443/__chsps__/login
 
         # REST basic-auth upload
-        curl -k -T README.rst https://test_user:test_password@docker.chevah.com:10443/home/README.rst
+        curl -k -T README.rst https://test_user:test_password@localhost:10443/home/README.rst
 
         # REST file download
-        curl -k  https://test_user:test_password@docker.chevah.com:10443/home/README.rst -o test-download.txt
+        curl -k  https://test_user:test_password@localhost:10443/home/README.rst -o test-download.txt
         cmp --silent README.rst test-download.txt
         rm test-download.txt
 
     - name: Test FTPS
-      timeout-minutes: 10
+      timeout-minutes: 1
       run: |
         # FTP login dir listing
-        curl -k --ftp-ssl ftp://test_user:test_password@docker.chevah.com:10021
+        curl -k --ftp-ssl ftp://test_user:test_password@localhost:10021
         # FTPS upload
-        curl -k --ftp-ssl  -T README.rst ftp://test_user:test_password@docker.chevah.com:10021
+        curl -k --ftp-ssl  -T README.rst ftp://test_user:test_password@localhost:10021
         # FTPS download
-        curl -k --ftp-ssl ftp://test_user:test_password@docker.chevah.com:10021/README.rst -o test-download.rst
+        curl -k --ftp-ssl ftp://test_user:test_password@localhost:10021/README.rst -o test-download.rst
         cmp --silent README.rst test-download.txt
         rm test-download.txt
 
     - name: Test SFTP
-      timeout-minutes: 10
+      timeout-minutes: 1
       run: |
         # SFTP login and upload
         echo -n "test_password" > pwfile
-        echo y | pscp -sftp -P 10022 -l test_user -pwfile pwfile README.rst docker.chevah.com:README.rst
+        echo y | pscp -sftp -P 10022 -l test_user -pwfile pwfile README.rst localhost:README.rst
         # SFTP download
-        pscp -sftp -P 10022 -l test_user -pwfile pwfile docker.chevah.com:README.rst test-download.rst
+        pscp -sftp -P 10022 -l test_user -pwfile pwfile localhost:README.rst test-download.rst
         cmp --silent README.rst test-download.txt
         rm test-download.txt
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,44 +87,47 @@ jobs:
     - name: Test HTTPS
       timeout-minutes: 1
       run: |
+        echo "Web UI"
         curl -k https://localhost:10020
-        curl -k https://localhost:10443/home/
 
-        # HTTPS session login.
+        echo "HTTPS session login.""
         curl -k --data 'username=test_user' --data 'password=test_password' \
           -H 'Accept: application/json' \
           https://localhost:10443/__chsps__/login
 
-        # REST basic-auth upload
+        echo "REST basic-auth upload"
         curl -k -T README.rst https://test_user:test_password@localhost:10443/home/README.rst
 
-        # REST file download
-        curl -k  https://test_user:test_password@localhost:10443/home/README.rst -o test-download.txt
-        cmp --silent README.rst test-download.txt
-        rm test-download.txt
+        echo "REST file download"
+        curl -k  https://test_user:test_password@localhost:10443/home/README.rst -o test-download.rst
+        echo "Compare download result"
+        cmp --silent README.rst test-download.rst
+        rm test-download.rst
 
     - name: Test FTPS
       timeout-minutes: 1
       run: |
-        # FTP login dir listing
+        echo "FTPS login dir listing"
         curl -k --ftp-ssl ftp://test_user:test_password@localhost:10021
-        # FTPS upload
-        curl -k --ftp-ssl  -T README.rst ftp://test_user:test_password@localhost:10021
-        # FTPS download
+        echo "FTPS upload"
+        curl -k --ftp-ssl -T README.rst ftp://test_user:test_password@localhost:10021
+        echo "FTPS download"
         curl -k --ftp-ssl ftp://test_user:test_password@localhost:10021/README.rst -o test-download.rst
-        cmp --silent README.rst test-download.txt
-        rm test-download.txt
+        echo "Compare download result"
+        cmp README.rst test-download.rst
+        rm test-download.rst
 
     - name: Test SFTP
       timeout-minutes: 1
       run: |
-        # SFTP login and upload
+        echo "SFTP login and upload"
         echo -n "test_password" > pwfile
         echo y | pscp -sftp -P 10022 -l test_user -pwfile pwfile README.rst localhost:README.rst
-        # SFTP download
+        echo "SFTP download"
         pscp -sftp -P 10022 -l test_user -pwfile pwfile localhost:README.rst test-download.rst
-        cmp --silent README.rst test-download.txt
-        rm test-download.txt
+        echo "Compare download result"
+        cmp README.rst test-download.rst
+        rm test-download.rst
 
     - name: Debug via tmate session
       if: ${{ !cancelled() && runner.debug == '1' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
         rm test-download.txt
 
     - name: Debug via tmate session
-      if: ${{ runner.debug == "1" }}
+      if: runner.debug == '1'
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /sftpplus-*.tar.gz
+/credentials/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,15 @@
 # * alpine:3.16
 ARG base_image=ubuntu:22.04
 ARG target_platform=lnx-x64
+################################################################################
+# Image details
+#
+
+FROM $base_image
+# Need to repeat them to be available after FROM
+# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG base_image
+ARG target_platform
 
 # SFTPPlus moniker for the current OS (e.g. "rhel8-x64", "ubuntu2004-x64", "alpine312-x64").
 ENV SFTPPLUS_PLATFORM $target_platform

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # * ubuntu:22:04
 # * alpine:3.16
 ARG base_image=ubuntu:22.04
-ARG target_platform=lnx-x64
+
 ################################################################################
 # Image details
 #
@@ -19,13 +19,14 @@ FROM $base_image
 # Need to repeat them to be available after FROM
 # See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG base_image
-ARG target_platform
+ARG target_platform=lnx-x64
+ARG sftpplus_version=trial
 
 # SFTPPlus moniker for the current OS (e.g. "rhel8-x64", "ubuntu2004-x64", "alpine312-x64").
 ENV SFTPPLUS_PLATFORM $target_platform
 
 # For the non-trial package, this would be the version, eg. "4.0.0".
-ENV SFTPPLUS_VERSION trial
+ENV SFTPPLUS_VERSION $sftpplus_version
 
 # Official Dockerfile for SFTPPlus.
 MAINTAINER support@sftpplus.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@
 # * ubuntu:20.04
 # * alpine:3.12
 
-ARG base_image="alpine:3.12"
-ARG target_platform=alpine312-x64
+ARG base_image="ubuntu:20.04"
+ARG target_platform=ubuntu2004-x64
 
 ###############################################################################
 # Image details
@@ -45,7 +45,7 @@ EXPOSE 10020 10443 10022 10021 10900-10910
 #
 
 # Add the files needed to customize the image.
-ADD sftpplus-${SFTPPLUS_PLATFORM}-${SFTPPLUS_VERSION}.tar.gz sftpplus-docker-setup.sh /opt/
+ADD sftpplus-${SFTPPLUS_PLATFORM}-${SFTPPLUS_VERSION}.tar.gz sftpplus-docker-setup.sh sftpplus-docker-entrypoint.sh /opt/
 ADD configuration/ /opt/configuration/
 
 # Unpack the tarball and initialize setup.
@@ -54,7 +54,7 @@ RUN /opt/sftpplus-docker-setup.sh
 # SFTPPlus install dir.
 WORKDIR /opt/sftpplus
 
-# The Dockerfile USER instruction is ignored on OpneShift, where a different
+# The Dockerfile USER instruction is ignored on OpenShift, where a different
 # arbitrary user ID is used for each container
 USER sftpplus
 
@@ -62,4 +62,4 @@ USER sftpplus
 # To log to Docker only, the standard-stream event handler is enabled through
 # the default configuration file picked up from configuration/, which also
 # disables the default logging to file and SQLite database.
-CMD [ "bin/admin-commands.sh", "start-in-foreground" ]
+CMD [ "/bin/sh", "/opt/sftpplus-docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,10 @@
 # works with others as well, as long as you use the right SFTPPlus package):
 # * centos:8
 # * ubuntu:20.04
-# * alpine:3.12
-
-ARG base_image="ubuntu:20.04"
-ARG target_platform=ubuntu2004-x64
-
-###############################################################################
-# Image details
-#
-
-FROM $base_image
-# Need to repeat them to be available after FROM
-# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG base_image
-ARG target_platform
+# * ubuntu:22:04
+# * alpine:3.16
+ARG base_image=ubuntu:22.04
+ARG target_platform=lnx-x64
 
 # SFTPPlus moniker for the current OS (e.g. "rhel8-x64", "ubuntu2004-x64", "alpine312-x64").
 ENV SFTPPLUS_PLATFORM $target_platform

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-SFTPPlus Docker
-===============
+SFTPPlus Docker example
+=======================
 
 This repository contains a ``Dockerfile`` and related files for creating Docker
 containers running Pro:Atria's SFTPPlus Managed File Transfer for evaluation
@@ -36,8 +36,8 @@ either the trial or the full version.
 This repository contains examples for the following operating systems:
 
 * RHEL 8 / CentOS 8
-* Ubuntu 20.04
-* Alpine 3.12
+* Ubuntu 20.04 / Ubuntu 22.04
+* Alpine 3.16
 
 
 Docker Image Creation

--- a/README.rst
+++ b/README.rst
@@ -82,19 +82,19 @@ Launching a container
 ---------------------
 
 * Once the image is created, you can start a new Docker container using it.
-  In the following example, we run a container named ``sftpplus-trial-instance``
+  In the following example, we run a container named ``sftpplus-trial``
   using the ``sftpplus:4.0.0.trial`` image, which publishes its default services
   to the outside world. There are a few standard ports open by default
   (for the administrative interface, HTTPS service, SSH service, explicit FTP
   service and its passive ports range respectively)::
 
-    docker run --detach --name sftpplus-trial-instance \
+    docker run --detach --name sftpplus-trial \
         --publish 10020:10020 \
         --publish 10443:10443 \
         --publish 10022:10022 \
         --publish 10021:10021 \
         --publish 10900-10910:10900-10910 \
-        sftpplus:test.trial
+        sftpplus:4.0.0.trial
 
 * You can check that the container is started with::
 
@@ -102,7 +102,7 @@ Launching a container
 
 * And check its logs with::
 
-    docker logs sftpplus-trial-instance
+    docker logs sftpplus-trial
 
 If everything looks fine, you should be able to access the administrative
 web-based interface on port 10020, e.g. at https://DOCKER_ADDRESS:10020. Also,
@@ -111,15 +111,15 @@ https://DOCKER_ADDRESS:10443.
 
 * To inspect a container which is already running::
 
-    docker exec --interactive --tty sftpplus-trial-instance /bin/sh
+    docker exec --interactive --tty sftpplus-trial /bin/sh
 
 * You can stop the container with::
 
-    docker stop sftpplus-trial-instance
+    docker stop sftpplus-trial
 
 * And then remove it with::
 
-    docker rm sftpplus-trial-instance
+    docker rm sftpplus-trial
 
 * To remove the trial image altogether::
 
@@ -163,7 +163,7 @@ before running it::
 Then we should mount this to ``/srv/storage`` (as per the included configuration
 file) when running the container::
 
-    docker run --detach --name sftpplus-trial-instance \
+    docker run --detach --name sftpplus-trial \
         --publish 10020:10020 \
         --publish 10443:10443 \
         --publish 10022:10022 \
@@ -172,7 +172,7 @@ file) when running the container::
         --mount source=sftpplus_trial_storage,target=/srv/storage \
         sftpplus:4.0.0.trial
 
-Use ``docker inspect sftpplus-trial-instance`` to verify that the volume
+Use ``docker inspect sftpplus-trial`` to verify that the volume
 was created and mounted correctly. Look for the ``Mounts`` section::
 
     "Mounts": [

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,10 @@ Docker Image Creation
 * Clone this repository.
 
 * Get your preferred SFTPPlus version.
-  The following example uses the link for the RHEL 8 / CentOS 8 trial,
+  The following example uses the link for the generic Linux trial,
   but you can replace it with your full version download link::
 
-    wget https://download.sftpplus.com/trial/sftpplus-ubuntu2004-x64-trial.tar.gz
+    wget https://download.sftpplus.com/trial/sftpplus-lnx-x64-trial.tar.gz
 
 * Advanced users should edit the ``configuration/server.ini`` file to match
   their needs.
@@ -61,15 +61,16 @@ Docker Image Creation
 
 * From inside the main directory, build the ``sftpplus`` image with
   (replace ``4.0.0.trial`` with your preferred tag).
-  This will create an Alpine based image by default::
+  This will create an Ubuntu based image by default::
 
     docker build --tag sftpplus:4.0.0.trial .
 
 * Optionally, you can use build arguments to target a specific OS::
 
    docker build \
-    --build-arg "target_platform=ubuntu2004-x64" \
-    --build-arg "base_image=ubuntu:20.04" \
+    --build-arg "target_platform=lnx-x64" \
+    --build-arg "base_image=ubuntu:22.04" \
+    --build-arg "sftpplus_version=trial" \
     --tag sftpplus:4.0.0.trial .
 
 * If successful, the following should list the newly-available Docker image::
@@ -93,7 +94,7 @@ Launching a container
         --publish 10022:10022 \
         --publish 10021:10021 \
         --publish 10900-10910:10900-10910 \
-        sftpplus:4.0.0.trial
+        sftpplus:test.trial
 
 * You can check that the container is started with::
 

--- a/configuration/server.ini.seed
+++ b/configuration/server.ini.seed
@@ -35,12 +35,8 @@ password_minimum_length = 8
 password_hashing_scheme = crypt-sha512
 
 ; Self-signed SSL certificate and private SSH keys to be generated.
-ssl_certificate = configuration/self_signed_certificate.pem
-rsa_private_key = configuration/ssh_host_rsa_key
-dsa_private_key = configuration/ssh_host_dsa_key
-
-
-[remote_admin]
+ssl_certificate = configuration/ssl_certificate.pem
+ssh_host_keys = configuration/ssh_host_keys
 
 
 [authentications/DEFAULT-AUTHENTICATION]

--- a/configuration/server.ini.seed
+++ b/configuration/server.ini.seed
@@ -36,7 +36,7 @@ password_hashing_scheme = crypt-sha512
 
 ; Self-signed SSL certificate and private SSH keys to be generated.
 ssl_certificate = configuration/ssl_certificate.pem
-ssh_host_keys = configuration/ssh_host_keys
+ssh_host_private_keys = configuration/ssh_host_keys
 
 
 [authentications/DEFAULT-AUTHENTICATION]
@@ -125,18 +125,11 @@ description = Example of a SFTP only service.
 address = 0.0.0.0
 port = 10022
 
-; When there are no specific host keys and/or certificates,
-; the general configuration from [server] section is used.
-;rsa_private_key = configuration/ssh_host_rsa_key
-;rsa_private_key_password = Disabled
-;dsa_private_key = configuration/ssh_host_dsa_key
-;dsa_private_key_password = Disabled
 ssh_cipher_list = secure
 banner = Welcome to the SFTP Service.
 ignore_create_permissions = No
 idle_connection_timeout = 300
 maximum_concurrent_connections = Disabled
-
 
 [services/ftps-1]
 enabled = Yes
@@ -156,19 +149,8 @@ enable_password_authentication = Yes
 enable_ssl_certificate_authentication = Yes
 ignore_ascii_data_type = No
 ascii_data_type_as_default = No
-; When there are no specific host keys and/or certificates,
-; the general configuration from [server] section is used.
-;ssl_certificate = configuration/self_signed_certificate.pem
-;ssl_key = configuration/ftp-service-key.pem
-;ssl_key_password = Disabled
-;ssl_certificate_authority = configuration/ftps-ca-cert.pem
-;ssl_certificate_revocation_list = configuration/ftps-crl.pem
-; Reload CRL after one day.
-;ssl_certificate_revocation_list_refresh = 86400
-;ssl_cipher_list = ALL:!RC4:!DES:!MD5:!EXP
-;ssl_allowed_methods = tlsv1
 idle_connection_timeout = 300
-maximum_concurrent_connections = Disabled
+maximum_concurrent_connections = 1000
 idle_data_connection_timeout = 30
 
 
@@ -179,11 +161,6 @@ protocol = https
 description = A demo text describing the purpose of this HTTPS service.
 address = 0.0.0.0
 port = 10443
-
-; When there are no specific host keys and/or certificates,
-; the general configuration from [server] section is used.
-;ssl_certificate = configuration/self_signed_certificate.pem
-;ssl_key = configuration/ftp-service-key.pem
 
 
 [resources/DEFAULT-LETS-ENCRYPT]

--- a/sftpplus-docker-entrypoint.sh
+++ b/sftpplus-docker-entrypoint.sh
@@ -7,18 +7,22 @@ if [ -f "${SFTPPLUS_CONFIGURATION}/server.ini" ]; then
     echo "Configuration directory already initialized."
 else
   echo "Initializing the configuration"
+  mkdir -p ${SFTPPLUS_CONFIGURATION}
   cp /opt/sftpplus/configuration/server.ini.seed ${SFTPPLUS_CONFIGURATION}/server.ini
   ./bin/admin-commands.sh generate-self-signed \
     --common-name=sftpplus-docker.example.com \
     --key-size=2048 \
     --sign-algorithm=sha256 \
-    > configuration/ssl_certificate.pem
+    > ${SFTPPLUS_CONFIGURATION}/ssl_certificate.pem
   ./bin/admin-commands.sh generate-ssh-key \
-    --key-file=configuration/ssh_host_keys \
+    --key-file=${SFTPPLUS_CONFIGURATION}/ssh_host_keys \
     --key-type=rsa \
     --key-size=2048
+  # Cleanup public key as we don't need it.
+  rm ${SFTPPLUS_CONFIGURATION}/ssh_host_keys.pub
 fi
 
 echo "Starting using configuration from: $SFTPPLUS_CONFIGURATION"
-cd /opt/sftpplus
-./bin/admin-commands.sh start-in-foreground --config="$SFTPPLUS_CONFIGURATION/server.ini"
+cd ${SFTPPLUS_CONFIGURATION}/../
+/opt/sftpplus/bin/admin-commands.sh start-in-foreground \
+  --config="$SFTPPLUS_CONFIGURATION/server.ini"

--- a/sftpplus-docker-entrypoint.sh
+++ b/sftpplus-docker-entrypoint.sh
@@ -1,0 +1,28 @@
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] ; then
+    echo "Google Cloud storage disabled"
+else
+    echo "Mounting Google Cloud storage bucket '$GCS_BUCKET' in /srv/storage"
+    gcsfuse -o nonempty $GCS_BUCKET /srv/storage/
+fi
+
+if [ -z "$S3_CREDENTIALS" ] ; then
+    echo "S3 Cloud storage disabled"
+else
+    s3fs $S3_BUCKET /srv/storage -o nonempty -o passwd_file="${S3_CREDENTIALS}"
+fi
+
+if [ -z "$SFTPPLUS_CONFIGURATION" ] ; then
+    # Use default configuration directory.
+    SFTPPLUS_CONFIGURATION=/opt/sftpplus/configuration
+fi
+
+if [ -d "$SFTPPLUS_CONFIGURATION" ]; then
+    echo "Configuration directory already initialized."
+else
+  echo "Initializing the configuration directory"
+  cp -r /opt/sftpplus/configuration $SFTPPLUS_CONFIGURATION
+fi
+
+echo "Starting using configuration from: $SFTPPLUS_CONFIGURATION"
+cd /opt/sftpplus
+./bin/admin-commands.sh start-in-foreground --config="$SFTPPLUS_CONFIGURATION/server.ini"

--- a/sftpplus-docker-setup.sh
+++ b/sftpplus-docker-setup.sh
@@ -1,4 +1,4 @@
-# To be used with the SFTPPlus Dockerfile for cloud deployment
+# To be used with the SFTPPlus Dockerfile.
 
 # Get relevant deps per distribution installed.
 . /etc/os-release
@@ -39,8 +39,17 @@ mv sftpplus-${SFTPPLUS_PLATFORM}-* sftpplus
 mv /opt/configuration/* /opt/sftpplus/configuration/
 rm -rf /opt/configuration
 
-groupadd sftpplus
-useradd -g sftpplus -c "SFTPPlus" -s /bin/false -d /dev/null -M sftpplus
+# Add default group and user.
+case ${ID} in
+    alpine)
+        addgroup sftpplus
+        adduser -G sftpplus -g "SFTPPlus" -s /bin/false -h /dev/null -H -D sftpplus
+        ;;
+    *)
+        groupadd sftpplus
+        useradd -g sftpplus -c "SFTPPlus" -s /bin/false -d /dev/null -M sftpplus
+        ;;
+esac
 
 # Create the basic storage directory for the default-enabled test_user account.
 mkdir -p /srv/storage/test_user

--- a/sftpplus-docker-setup.sh
+++ b/sftpplus-docker-setup.sh
@@ -13,7 +13,20 @@ case ${ID} in
     ubuntu|debian)
         # Get the OpenSSL and libffi libraries, the only dependencies.
         apt-get update
-        apt-get install -y openssl libffi7
+        apt-get install -fy openssl libffi7 fuse wget s3fs
+
+        #apt-get install -fy software-properties-common
+        #echo "deb http://packages.cloud.google.com/apt gcsfuse-focal main" > /etc/apt/sources.list.d/gcsfuse.list
+        #curl -L https://packages.cloud.google.com/apt/doc/apt-key.gpg -o repo.key
+        #apt-key add repo.key
+        #rm repo.key
+        #apt-get update
+        #apt-get install -y gcsfuse
+
+        # Download the file from GitHub and then fix the dependencies
+        wget -q https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.35.1/gcsfuse_0.35.1_amd64.deb
+        dpkg -i gcsfuse*.deb
+        apt --fix-broken install
         apt-get clean
         ;;
     alpine)
@@ -70,6 +83,8 @@ esac
 
 # Create the basic storage directory for the default-enabled test_user account.
 mkdir -p /srv/storage/test_user
+
+chmod +x /opt/sftpplus-docker-entrypoint.sh
 
 # Adjust ownership of the configuration files and logs.
 chown -R sftpplus \

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,23 @@
+# Helper to test and develop the container.
+# Starts the container using the local docker.
+#
+#docker image rm sftpplus:debug
+#docker build -t sftpplus:debug .
+docker rm -f sftpplus-debug
+docker run -ti --name sftpplus-debug \
+    --device /dev/fuse \
+    --privileged \
+    --cap-add SYS_ADMIN \
+    -v `pwd`/credentials:/srv/credentials \
+    -p 10020:10020/tcp -p 10022:10022/tcp \
+    # To run with custom configuration directory
+    -e SFTPPLUS_CONFIGURATION=/srv/storage/configuration \
+    sftpplus:debug
+    # To run with Google Cloud Storage
+    # -e GOOGLE_APPLICATION_CREDENTIALS=/srv/credentials/gcs-key.json \
+    # -e GCS_BUCKET=sftpplus-trial-srv-storage \
+    # To run with AWS S3
+    # -e S3_BUCKET=sftpplus-trial-srv-storage \
+    # -e S3_CREDENTIALS=/srv/credentials/s3fs-passwd \
+
+docker rm -f sftpplus-debug

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
 # Helper to test and develop the container.
 # Starts the container using the local docker.
 #
-#docker image rm sftpplus:debug
-#docker build -t sftpplus:debug .
+docker image rm sftpplus:debug
+docker build -t sftpplus:debug .
 docker rm -f sftpplus-debug
 docker run -ti --name sftpplus-debug \
     --device /dev/fuse \
@@ -10,12 +10,10 @@ docker run -ti --name sftpplus-debug \
     --cap-add SYS_ADMIN \
     -v `pwd`/credentials:/srv/credentials \
     -p 10020:10020/tcp -p 10022:10022/tcp \
-    # To run with custom configuration directory
     -e SFTPPLUS_CONFIGURATION=/srv/storage/configuration \
-    sftpplus:debug
-    # To run with Google Cloud Storage
-    # -e GOOGLE_APPLICATION_CREDENTIALS=/srv/credentials/gcs-key.json \
-    # -e GCS_BUCKET=sftpplus-trial-srv-storage \
+    sftpplus:debug bash
+
+
     # To run with AWS S3
     # -e S3_BUCKET=sftpplus-trial-srv-storage \
     # -e S3_CREDENTIALS=/srv/credentials/s3fs-passwd \

--- a/test.sh
+++ b/test.sh
@@ -5,17 +5,8 @@ docker image rm sftpplus:debug
 docker build -t sftpplus:debug .
 docker rm -f sftpplus-debug
 docker run -ti --name sftpplus-debug \
-    --device /dev/fuse \
-    --privileged \
-    --cap-add SYS_ADMIN \
-    -v `pwd`/credentials:/srv/credentials \
     -p 10020:10020/tcp -p 10022:10022/tcp \
     -e SFTPPLUS_CONFIGURATION=/srv/storage/configuration \
-    sftpplus:debug bash
-
-
-    # To run with AWS S3
-    # -e S3_BUCKET=sftpplus-trial-srv-storage \
-    # -e S3_CREDENTIALS=/srv/credentials/s3fs-passwd \
+    sftpplus:debug  # /bin/bash  # if you don't what to auto-start.
 
 docker rm -f sftpplus-debug

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,18 @@
 # Helper to test and develop the container.
 # Starts the container using the local docker.
 #
-docker image rm sftpplus:debug
+
+if [ -n "$(docker images -q sftpplus:debug)" ]; then
+    docker image rm sftpplus:debug
+fi
 docker build -t sftpplus:debug .
-docker rm -f sftpplus-debug
+if [ "$(docker ps -a -f name=sftpplus-debug | wc -l)" -gt 1 ]; then
+    docker rm -f sftpplus-debug
+fi
 docker run -ti --name sftpplus-debug \
     -p 10020:10020/tcp -p 10022:10022/tcp \
     -e SFTPPLUS_CONFIGURATION=/srv/storage/configuration \
     sftpplus:debug  # /bin/bash  # if you don't what to auto-start.
 
 docker rm -f sftpplus-debug
+docker image rm sftpplus:debug


### PR DESCRIPTION
Scope
=====

Fixes #8

The trial container is nice, but it has no persistence.

Also, the seed configuration is old.

Also, the image is built with static private key... which is bad.
The private key should be generated at run-time, if no config exits.

Changes
=======

Add support to load the config from a different directory.
In this way, you can mount a volume with the config and inject your persistance.

Refactor the image setup and entrypoint to generate the SSH/SSL key at runtime.
Without this, multiple people could use the image and user the same private key.

The config file was updated for latest changes.

Add support for Ubuntu 22.04

I have already pushed proatria/sftpplus-trial:latest based on this image as trial was not updated in the last 5 months.


How to test
==========

reviewers: @dumol 

I plan to use this for a K8s deployment demo.

There is test.sh script that will build the image and spin a container.

